### PR TITLE
Fix ClangSharp build

### DIFF
--- a/TerathonPortGenerator/TerathonPortGenerator/TerathonPortGenerator.csproj
+++ b/TerathonPortGenerator/TerathonPortGenerator/TerathonPortGenerator.csproj
@@ -5,6 +5,7 @@
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
- update generator to use current ClangSharp API
- allow unsafe code for visiting cursors

## Testing
- `dotnet build TerathonPortGenerator.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_687641176e38832a93fda310c185d0f1