### PR TITLE
Fix ClangSharp runtime loading

### DIFF
--- a/TerathonPortGenerator/TerathonPortGenerator/TerathonPortGenerator.csproj
+++ b/TerathonPortGenerator/TerathonPortGenerator/TerathonPortGenerator.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net8.0</TargetFramework>
+    <RuntimeIdentifier>linux-x64</RuntimeIdentifier>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
@@ -11,6 +12,8 @@
   <ItemGroup>
     <PackageReference Include="ClangSharp" Version="20.1.2.1" />
     <PackageReference Include="ClangSharp.Interop" Version="20.1.2.1" />
+    <PackageReference Include="libClangSharp" Version="20.1.2" />
+    <PackageReference Include="libclang" Version="20.1.2" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary
- add native runtime packages for ClangSharp
- specify linux-x64 runtime so native libraries are copied

## Testing
- `dotnet build TerathonPortGenerator/TerathonPortGenerator/TerathonPortGenerator.csproj -c Release`
- `dotnet run --project TerathonPortGenerator/TerathonPortGenerator/TerathonPortGenerator.csproj TerathonPortGenerator/Terathon-Math-Library TerathonPortGenerator/Terathon-Math-Library-CSharp`


------
https://chatgpt.com/codex/tasks/task_e_68764700029c832a92e696ec6beb8e05