### PR TITLE
Remove unused vector interface

### DIFF
--- a/TerathonPortGenerator/TerathonPortGenerator.Tests/GeneratorTests.cs
+++ b/TerathonPortGenerator/TerathonPortGenerator.Tests/GeneratorTests.cs
@@ -1,0 +1,31 @@
+using System.Collections.Generic;
+using TerathonPortGenerator;
+using Xunit;
+
+namespace TerathonPortGenerator.Tests;
+
+public class GeneratorTests
+{
+	[Fact]
+	public void StructGeneratorDoesNotImplementIVector()
+	{
+		var typeInfo = new TypeInfo(
+			"Vector2D",
+			8,
+			new List<FieldInfo>{
+				new FieldInfo("X", "float", "float", 0),
+				new FieldInfo("Y", "float", "float", 4)
+			},
+			new List<MethodInfo>());
+
+		var code = StructGenerator.Generate(typeInfo);
+		Assert.DoesNotContain("IVector", code);
+	}
+
+	[Fact]
+	public void InterfaceGeneratorReturnsEmpty()
+	{
+		var code = InterfaceGenerator.Generate();
+		Assert.True(string.IsNullOrWhiteSpace(code) || !code.Contains("IVector"));
+	}
+}

--- a/TerathonPortGenerator/TerathonPortGenerator.Tests/TerathonPortGenerator.Tests.csproj
+++ b/TerathonPortGenerator/TerathonPortGenerator.Tests/TerathonPortGenerator.Tests.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit" Version="2.5.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
+    <ProjectReference Include="../TerathonPortGenerator/TerathonPortGenerator.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+</Project>

--- a/TerathonPortGenerator/TerathonPortGenerator.sln
+++ b/TerathonPortGenerator/TerathonPortGenerator.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 17.14.36301.6
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TerathonPortGenerator", "TerathonPortGenerator\TerathonPortGenerator.csproj", "{B21FA4AF-0FE3-404C-B913-72D4D9CBBB60}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TerathonPortGenerator.Tests", "TerathonPortGenerator.Tests\TerathonPortGenerator.Tests.csproj", "{68F4CB14-E091-45F5-9AD9-522ED52D4C0E}"
+EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Terathon-Math-Library", "Terathon-Math-Library", "{8EC462FD-D22E-90A8-E5CE-7E832BA40C5D}"
 	ProjectSection(SolutionItems) = preProject
 		Terathon-Math-Library\TSAlgebra.h = Terathon-Math-Library\TSAlgebra.h
@@ -58,12 +60,16 @@ Global
 		{B21FA4AF-0FE3-404C-B913-72D4D9CBBB60}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{B21FA4AF-0FE3-404C-B913-72D4D9CBBB60}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{B21FA4AF-0FE3-404C-B913-72D4D9CBBB60}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{B21FA4AF-0FE3-404C-B913-72D4D9CBBB60}.Release|Any CPU.Build.0 = Release|Any CPU
-		{76663B0C-3E42-41D2-8DD7-EDA9D4B4B0EE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{76663B0C-3E42-41D2-8DD7-EDA9D4B4B0EE}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{76663B0C-3E42-41D2-8DD7-EDA9D4B4B0EE}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{76663B0C-3E42-41D2-8DD7-EDA9D4B4B0EE}.Release|Any CPU.Build.0 = Release|Any CPU
-	EndGlobalSection
+               {B21FA4AF-0FE3-404C-B913-72D4D9CBBB60}.Release|Any CPU.Build.0 = Release|Any CPU
+               {76663B0C-3E42-41D2-8DD7-EDA9D4B4B0EE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+               {76663B0C-3E42-41D2-8DD7-EDA9D4B4B0EE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+               {76663B0C-3E42-41D2-8DD7-EDA9D4B4B0EE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+               {76663B0C-3E42-41D2-8DD7-EDA9D4B4B0EE}.Release|Any CPU.Build.0 = Release|Any CPU
+                {68F4CB14-E091-45F5-9AD9-522ED52D4C0E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {68F4CB14-E091-45F5-9AD9-522ED52D4C0E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {68F4CB14-E091-45F5-9AD9-522ED52D4C0E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {68F4CB14-E091-45F5-9AD9-522ED52D4C0E}.Release|Any CPU.Build.0 = Release|Any CPU
+        EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection


### PR DESCRIPTION
## Summary
- drop IVector interface generation and related struct inheritance
- expose generator helpers as public
- add basic xUnit tests

## Testing
- `dotnet format TerathonPortGenerator/TerathonPortGenerator.sln --no-restore`
- `dotnet test TerathonPortGenerator/TerathonPortGenerator.sln -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_687653239dec832a89eade497960f66d